### PR TITLE
chore: validate absolute output path argument

### DIFF
--- a/__tests__/@types/setup.type.ts
+++ b/__tests__/@types/setup.type.ts
@@ -1,3 +1,4 @@
 export interface TestConstants {
     promptCounter: number;
+    originalArgv: string[];
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "gs-hygen": "build/setup.js"
     },
     "scripts": {
-        "test": "npx jest --runInBand --verbose",
+        "test": "npx jest --runInBand --verbose true",
         "test:debug": "DEBUG=unit:tests* npm run test",
         "test:watch": "npm run test -- --watchAll",
         "test:watch:debug": "npm run test:watch",

--- a/setup.ts
+++ b/setup.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// LIBs
+// Libs
 import { parseCliArguments } from './src/utils/arguments';
 import { clone as gitClone } from './src/utils/git';
 import { testOutputFiles } from './src/utils/checks';
@@ -14,10 +14,11 @@ import colors from 'colors';
 import path from 'path';
 import execa from 'execa';
 import { Spinner } from 'cli-spinner';
-import { existsSync } from 'fs-extra';
+import { existsSync, readFileSync } from 'fs-extra';
 import { runner as hygen, Logger } from 'hygen';
 
-export async function main(argumentsList: ArgumentsList): Promise<void> {
+export async function main(): Promise<void> {
+    const argumentsList: ArgumentsList = parseCliArguments();
     const templatesPath: string = path.join(__dirname, '_templates/');
     if (existsSync(templatesPath)) {
         del.sync(templatesPath);
@@ -27,8 +28,8 @@ export async function main(argumentsList: ArgumentsList): Promise<void> {
         url: argumentsList.url,
         destination: templatesPath,
         username: argumentsList.username,
-        publicKey: argumentsList.publicKey,
-        privateKey: argumentsList.privateKey,
+        publicKey: argumentsList.publicKey ? readFileSync(argumentsList.publicKey).toString() : '',
+        privateKey: argumentsList.privateKey ? readFileSync(argumentsList.privateKey).toString() : '',
         credentials: argumentsList.credentials,
     });
     const generators: string[] = argumentsList.generator.split(',');
@@ -59,6 +60,5 @@ export async function main(argumentsList: ArgumentsList): Promise<void> {
 }
 
 if (!process.env.AVOID_AUTOSTART) {
-    const argumentsList: ArgumentsList = parseCliArguments();
-    main(argumentsList);
+    main();
 }

--- a/src/types/argument.ts
+++ b/src/types/argument.ts
@@ -1,9 +1,11 @@
+import { PathLike } from 'fs-extra';
+
 export interface ArgumentsList {
     generator: string;
     output: string;
     url?: string;
     username?: string;
     credentials?: string;
-    publicKey?: string;
-    privateKey?: string;
+    publicKey?: PathLike;
+    privateKey?: PathLike;
 }

--- a/src/utils/arguments.ts
+++ b/src/utils/arguments.ts
@@ -1,24 +1,31 @@
 // Modules
 import yargs from 'yargs';
 import { get } from 'lodash';
-import { PathLike, readFileSync } from 'fs-extra';
+import { PathLike } from 'fs-extra';
+// Libs
+import { isAbsolutePath } from './validator';
 // Types
 import { ArgumentsList } from '../types/argument';
 
 function parseCliArgumentsToList(yargsArguments): ArgumentsList {
-    return {
+    const argumentsList: ArgumentsList = {
         url: get(yargsArguments, 'url') as string,
         generator: get(yargsArguments, 'generator') as string,
         output: get(yargsArguments, 'output') as string,
         username: get(yargsArguments, 'username') as string,
         credentials: get(yargsArguments, 'credentials') as string,
-        publicKey: readFileSync(get(yargsArguments, 'public-key') as PathLike).toString(),
-        privateKey: readFileSync(get(yargsArguments, 'private-key') as PathLike).toString(),
+        publicKey: get(yargsArguments, 'public-key') as PathLike,
+        privateKey: get(yargsArguments, 'private-key') as PathLike,
     };
+    // Run validators
+    isAbsolutePath(argumentsList.output);
+
+    // Return values after success validation
+    return argumentsList;
 }
 
 export function parseCliArguments(): ArgumentsList {
-    const yargsArguments = yargs
+    const yargsArguments = yargs(process.argv.slice(2))
         .command('template', 'Template command')
         .options({
             url: {

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,0 +1,14 @@
+// Modules
+import { isAbsolute } from 'path';
+
+const errorMessages: {
+    isNotAbsolutePath: (value: string) => Error;
+} = {
+    isNotAbsolutePath: (value: string): Error => new Error(`The provided value "${value}" is not an absolute path`),
+};
+
+export function isAbsolutePath(value: string): void {
+    if (!isAbsolute(value)) {
+        throw errorMessages.isNotAbsolutePath(value);
+    }
+}


### PR DESCRIPTION
Mock **_process.argv_** from jest tests.
Now the output path is validated for checking if it's an absolute path.